### PR TITLE
Use frameTime instead of progress

### DIFF
--- a/LottiePlayer/Base.lproj/Main.storyboard
+++ b/LottiePlayer/Base.lproj/Main.storyboard
@@ -764,17 +764,31 @@
                                 <rect key="frame" x="0.0" y="0.0" width="480" height="32"/>
                                 <subviews>
                                     <slider verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="erj-1Q-mIY">
-                                        <rect key="frame" x="18" y="7" width="444" height="19"/>
+                                        <rect key="frame" x="58" y="7" width="404" height="19"/>
                                         <sliderCell key="cell" continuous="YES" alignment="left" maxValue="1" tickMarkPosition="above" sliderType="linear" id="DFc-KR-uth"/>
                                         <connections>
                                             <action selector="sliderAction:" target="XfG-lQ-9wD" id="GYg-OZ-gMG"/>
                                         </connections>
                                     </slider>
+                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="edZ-nA-O3k">
+                                        <rect key="frame" x="18" y="8" width="36" height="16"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="16" id="bqX-Na-mRm"/>
+                                        </constraints>
+                                        <textFieldCell key="cell" lineBreakMode="clipping" alignment="right" title="9999" id="pCe-9x-m7l">
+                                            <font key="font" metaFont="system"/>
+                                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                        </textFieldCell>
+                                    </textField>
                                 </subviews>
                                 <constraints>
-                                    <constraint firstItem="erj-1Q-mIY" firstAttribute="leading" secondItem="3u7-kd-r5Z" secondAttribute="leading" constant="20" id="NOJ-ig-JV0"/>
+                                    <constraint firstItem="erj-1Q-mIY" firstAttribute="leading" secondItem="3u7-kd-r5Z" secondAttribute="leading" constant="60" id="NOJ-ig-JV0"/>
+                                    <constraint firstItem="erj-1Q-mIY" firstAttribute="leading" secondItem="edZ-nA-O3k" secondAttribute="trailing" constant="8" id="Rzc-nN-hjD"/>
                                     <constraint firstItem="erj-1Q-mIY" firstAttribute="centerY" secondItem="3u7-kd-r5Z" secondAttribute="centerY" id="VZW-04-dol"/>
                                     <constraint firstAttribute="trailing" secondItem="erj-1Q-mIY" secondAttribute="trailing" constant="20" id="btS-dI-4Og"/>
+                                    <constraint firstItem="edZ-nA-O3k" firstAttribute="leading" secondItem="3u7-kd-r5Z" secondAttribute="leading" constant="20" id="qjT-GK-5Co"/>
+                                    <constraint firstItem="edZ-nA-O3k" firstAttribute="centerY" secondItem="3u7-kd-r5Z" secondAttribute="centerY" id="xQ1-Xw-LJp"/>
                                 </constraints>
                             </customView>
                         </subviews>
@@ -795,11 +809,13 @@
                     </view>
                     <connections>
                         <outlet property="draggingDestinationView" destination="yCb-n0-BMK" id="bsE-9C-Tti"/>
+                        <outlet property="frameLabel" destination="edZ-nA-O3k" id="S8m-o6-A8U"/>
                         <outlet property="playerView" destination="ucJ-aw-8u5" id="HIZ-yx-46q"/>
                         <outlet property="slider" destination="erj-1Q-mIY" id="WXP-gJ-LOR"/>
                     </connections>
                 </viewController>
                 <customObject id="rPt-NT-nkU" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
+                <userDefaultsController representsSharedInstance="YES" id="jHh-tS-K1z"/>
             </objects>
             <point key="canvasLocation" x="75" y="655"/>
         </scene>

--- a/LottiePlayer/Player/PlayerView.swift
+++ b/LottiePlayer/Player/PlayerView.swift
@@ -11,8 +11,8 @@ import Combine
 import Lottie
 
 class PlayerView: NSView {
+    var currentFrame: AnimationFrameTime? { animationView?.realtimeAnimationFrame }
 
-    var currentProgress: AnimationProgressTime? { animationView?.realtimeAnimationProgress }
     private var animationView: AnimationView?
     private var cancellable = Set<AnyCancellable>()
 
@@ -30,10 +30,10 @@ class PlayerView: NSView {
             .store(in: &cancellable)
     }
 
-    func setUpAnimation(filePath: String) {
+    func setUpAnimation(_ animation: Animation) {
         animationView?.removeFromSuperview()
 
-        let newView = Lottie.AnimationView(filePath: filePath)
+        let newView = AnimationView(animation: animation)
         newView.loopMode = .playOnce
         newView.contentMode = .scaleAspectFit
         newView.frame = CGRect(x: 0, y: 0, width: frame.width, height: frame.height)
@@ -41,25 +41,20 @@ class PlayerView: NSView {
         animationView = newView
     }
 
-    func play() {
-        animationView?.play()
-    }
-
     func playOrPause() {
-        let isAnimationPlaying = animationView?.isAnimationPlaying ?? false
-        if  isAnimationPlaying {
-            animationView?.pause()
+        guard
+            let animationView = animationView,
+            let animation = animationView.animation else { return }
+
+        if  animationView.isAnimationPlaying {
+            animationView.pause()
         } else {
-            animationView?.play(fromProgress: nil, toProgress: 1)
+            animationView.play(fromFrame: nil, toFrame: animation.endFrame)
         }
     }
 
-    func play(fromProgress: AnimationProgressTime?, toProgress: AnimationProgressTime) {
-        animationView?.play(
-            fromProgress: fromProgress,
-            toProgress: toProgress,
-            loopMode: .playOnce,
-            completion: nil)
+    func play(fromFrame: AnimationFrameTime?, toFrame: AnimationFrameTime) {
+        animationView?.play(fromFrame: fromFrame, toFrame: toFrame, loopMode: .playOnce, completion: nil)
     }
 
     func stop() {


### PR DESCRIPTION
- I want to control animation by frame instead of progress
    - Use  `AnimationView.play(fromFrame:toFrame:loopMode:completion:)`
- Show frameTime on left side of slider


Before  | After
------------- | ------------- 
<img width="487" alt="Screenshot 2020-06-11 9 22 30" src="https://user-images.githubusercontent.com/4963478/84331444-1b1cca00-abc5-11ea-9526-1cd239851ba3.png">|<img width="487" alt="Screenshot 2020-06-11 9 21 36" src="https://user-images.githubusercontent.com/4963478/84331451-22dc6e80-abc5-11ea-880f-fb6f7ae0272c.png">


