### PR TITLE
Bump lottie-ios from 3.4.1 to 3.5.0

### DIFF
--- a/LottiePlayer.xcodeproj/project.pbxproj
+++ b/LottiePlayer.xcodeproj/project.pbxproj
@@ -580,7 +580,7 @@
 				CODE_SIGN_IDENTITY = "Developer ID Application";
 				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 4;
+				CURRENT_PROJECT_VERSION = 5;
 				DEVELOPMENT_TEAM = CFQNNV56V3;
 				ENABLE_HARDENED_RUNTIME = YES;
 				INFOPLIST_FILE = LottiePlayer/Info.plist;
@@ -588,7 +588,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.4;
+				MARKETING_VERSION = 0.5;
 				PRODUCT_BUNDLE_IDENTIFIER = com.mnkd.LottiePlayer;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -606,7 +606,7 @@
 				CODE_SIGN_INJECT_BASE_ENTITLEMENTS = NO;
 				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 4;
+				CURRENT_PROJECT_VERSION = 5;
 				DEVELOPMENT_TEAM = CFQNNV56V3;
 				ENABLE_HARDENED_RUNTIME = YES;
 				INFOPLIST_FILE = LottiePlayer/Info.plist;
@@ -614,7 +614,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.4;
+				MARKETING_VERSION = 0.5;
 				OTHER_CODE_SIGN_FLAGS = "--timestamp";
 				PRODUCT_BUNDLE_IDENTIFIER = com.mnkd.LottiePlayer;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/LottiePlayer.xcodeproj/project.pbxproj
+++ b/LottiePlayer.xcodeproj/project.pbxproj
@@ -758,7 +758,7 @@
 			repositoryURL = "https://github.com/airbnb/lottie-ios";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 3.0.0;
+				minimumVersion = 3.5.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/LottiePlayer.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/LottiePlayer.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/airbnb/lottie-ios",
       "state" : {
-        "revision" : "b04b773957e3e359730590c2e7c16d8c3874ec50",
-        "version" : "3.4.1"
+        "revision" : "b4bd0604ded9574807f41b4004b57dd1226a30a4",
+        "version" : "3.5.0"
       }
     }
   ],

--- a/LottiePlayer/Player/PlayerView.swift
+++ b/LottiePlayer/Player/PlayerView.swift
@@ -39,6 +39,11 @@ class PlayerView: NSView {
         newView.loopMode = .playOnce
         newView.contentMode = .scaleAspectFit
         newView.frame = CGRect(x: 0, y: 0, width: frame.width, height: frame.height)
+
+        #if DEBUG
+        newView.logHierarchyKeypaths()
+        #endif
+
         addSubview(newView)
         animationView = newView
     }

--- a/LottiePlayer/Player/PlayerView.swift
+++ b/LottiePlayer/Player/PlayerView.swift
@@ -32,10 +32,10 @@ class PlayerView: NSView {
             .store(in: &cancellables)
     }
 
-    func setUpAnimation(_ animation: Animation) {
+    func setUpAnimation(_ animation: LottieAnimation) {
         animationView?.removeFromSuperview()
 
-        let newView = AnimationView(animation: animation)
+        let newView = LottieAnimationView(animation: animation)
         newView.loopMode = .playOnce
         newView.contentMode = .scaleAspectFit
         newView.frame = CGRect(x: 0, y: 0, width: frame.width, height: frame.height)
@@ -66,6 +66,6 @@ class PlayerView: NSView {
 
     // MARK: Private
 
-    private var animationView: AnimationView?
+    private var animationView: LottieAnimationView?
     private var cancellables = Set<AnyCancellable>()
 }

--- a/LottiePlayer/Player/PlayerViewModel.swift
+++ b/LottiePlayer/Player/PlayerViewModel.swift
@@ -25,7 +25,7 @@ final class PlayerViewModel {
     @Published var windowTitle: String = "LottiePlayer"
 
     let onSpaceKeyDown = PassthroughSubject<Void, Never>()
-    let onAnimationChanged = PassthroughSubject<Animation, Never>()
+    let onAnimationChanged = PassthroughSubject<LottieAnimation, Never>()
     let onAnimationEndFrameChanged = PassthroughSubject<AnimationFrameTime, Never>()
     let onFrameTimeChanged = PassthroughSubject<FrameTimeRange, Never>()
 
@@ -34,7 +34,7 @@ final class PlayerViewModel {
             if let url = fileURL {
                 windowTitle = url.lastPathComponent
 
-                if let animation = Animation.filepath(url.path) {
+                if let animation = LottieAnimation.filepath(url.path) {
                     self.animation = animation
                     onAnimationChanged.send(animation)
                     onAnimationEndFrameChanged.send(animation.endFrame)
@@ -79,5 +79,5 @@ final class PlayerViewModel {
 
     // MARK: Private
 
-    private var animation: Animation?
+    private var animation: LottieAnimation?
 }


### PR DESCRIPTION
Cannot update to version 4 for the following reasons:
- lottie-ios 4.x currently supports only ColorValueProvider.
- https://github.com/airbnb/lottie-ios/issues/1861